### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "README.md"

--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ B4 - 5 cách khác: `python /sdcard/<đường dẫn tệp>/main.py
 
 **Lưu ý:** cứ 20 giấy + 1GB.  
 
+[![Run on Repl.it](https://repl.it/badge/github/dangdan2807/bug-data-1111)](https://repl.it/github/dangdan2807/bug-data-1111)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).